### PR TITLE
16 custom button add model directly to qgis

### DIFF
--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -251,6 +251,11 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
                     self.tr("Success"), text, duration=5
                 )
 
+            # Refreshing the processing toolbox
+            QgsApplication.processingRegistry().providerById(
+                "model"
+            ).refreshAlgorithms()
+
 
 # TODO: do it QGIS task to have
 def download_resource_file(url: str, file_path: str):

--- a/qgis_hub_plugin/gui/resource_browser.ui
+++ b/qgis_hub_plugin/gui/resource_browser.ui
@@ -237,7 +237,7 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="0" colspan="2">
+         <item row="10" column="0" colspan="2">
           <widget class="QPushButton" name="pushButtonDownload">
            <property name="text">
             <string>Download</string>
@@ -248,6 +248,13 @@
           <widget class="QCheckBox" name="checkBoxOpenDirectory">
            <property name="text">
             <string>Open download directory</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0" colspan="2">
+          <widget class="QPushButton" name="addQGISPushButton">
+           <property name="text">
+            <string>Add to QGIS</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
If the current selected resource is a processing model, show a button to add the model directly to QGIS.

![image](https://github.com/qgis/QGIS-Hub-Plugin/assets/9210179/897d81e7-1065-41cc-bae2-a95e9923fb1b)
