### PR TITLE
Move the reload resources button & Better UX when reload resource

### DIFF
--- a/qgis_hub_plugin/core/api_client.py
+++ b/qgis_hub_plugin/core/api_client.py
@@ -23,9 +23,13 @@ def get_all_resources(params=None, force_update=False):
     # TODO: download in the background
     response = requests.get(BASE_URL, params=params)
 
-    # Store the response in a file
-    response_folder.mkdir(parents=True, exist_ok=True)
-    with open(response_file, "w") as f:
-        json.dump(response.json(), f)
+    if response.status_code == 200:
+        # Store the response in a file
+        response_folder.mkdir(parents=True, exist_ok=True)
+        with open(response_file, "w") as f:
+            json.dump(response.json(), f)
 
-    return response.json()
+        return response.json()
+
+    else:
+        return None

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from qgis.core import Qgis, QgsApplication
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QCoreApplication, QRegExp, QSize, Qt, QUrl, pyqtSlot
+from qgis.PyQt.QtCore import QRegExp, QSize, Qt, QUrl, pyqtSlot
 from qgis.PyQt.QtGui import (
     QDesktopServices,
     QIcon,
@@ -13,7 +13,6 @@ from qgis.PyQt.QtGui import (
     QStandardItemModel,
 )
 from qgis.PyQt.QtWidgets import (
-    QApplication,
     QDialog,
     QFileDialog,
     QGraphicsPixmapItem,
@@ -24,6 +23,7 @@ from qgis_hub_plugin.core.api_client import get_all_resources
 from qgis_hub_plugin.core.custom_filter_proxy import MultiRoleFilterProxyModel
 from qgis_hub_plugin.toolbelt import PlgLogger
 from qgis_hub_plugin.utilities.common import download_file, get_icon
+from qgis_hub_plugin.utilities.qgis_util import show_busy_cursor
 
 UI_CLASS = uic.loadUiType(
     os.path.join(os.path.dirname(__file__), "resource_browser.ui")
@@ -78,20 +78,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
 
         self.hide_preview()
 
-    def busy_cursor_decorator(func):
-        def wrapper(*args, **kwargs):
-            QApplication.setOverrideCursor(Qt.WaitCursor)
-            QCoreApplication.processEvents()
-
-            try:
-                return func(*args, **kwargs)
-            finally:
-                QApplication.restoreOverrideCursor()
-                QCoreApplication.processEvents()
-
-        return wrapper
-
-    @busy_cursor_decorator
+    @show_busy_cursor
     def populate_resources(self, force_update=False):
         if force_update or not self.resources:
             response = get_all_resources(force_update=force_update)

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -95,15 +95,23 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
     def populate_resources(self, force_update=False):
         if force_update or not self.resources:
             response = get_all_resources(force_update=force_update)
-            # total = response.get("total")
-            # previous_url = response.get("previous")
-            # next_url = response.get("next")
+
+            if response is None:
+                text = self.tr(f"Error populating the resources")
+                self.iface.messageBar().pushMessage(
+                    self.tr("Warning"), text, level=Qgis.Warning, duration=5
+                )
+                return
+
             self.resources = response.get("results", {})
 
         self.resource_model.clear()
         for resource in self.resources:
             item = ResourceItem(resource)
             self.resource_model.appendRow(item)
+
+        text = self.tr(f"Successfully populated the resources")
+        self.iface.messageBar().pushMessage(self.tr("Success"), text, duration=5)
 
     def update_checkbox_states(self):
         geopackage_checked = self.checkBoxGeopackage.isChecked()

--- a/qgis_hub_plugin/gui/resource_browser.ui
+++ b/qgis_hub_plugin/gui/resource_browser.ui
@@ -28,28 +28,47 @@
     <widget class="QWidget" name="widget_4" native="true">
      <layout class="QHBoxLayout">
       <item>
-       <widget class="QListView" name="listViewResources">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="sizeAdjustPolicy">
-         <enum>QAbstractScrollArea::AdjustIgnored</enum>
-        </property>
-        <property name="editTriggers">
-         <set>QAbstractItemView::NoEditTriggers</set>
-        </property>
-        <property name="resizeMode">
-         <enum>QListView::Adjust</enum>
-        </property>
-        <property name="viewMode">
-         <enum>QListView::IconMode</enum>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
+       <widget class="QWidget" name="widget_5" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QListView" name="listViewResources">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QAbstractScrollArea::AdjustIgnored</enum>
+           </property>
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+           <property name="resizeMode">
+            <enum>QListView::Adjust</enum>
+           </property>
+           <property name="viewMode">
+            <enum>QListView::IconMode</enum>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="reloadPushButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Reload Resources</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>
@@ -387,19 +406,6 @@
        </layout>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QPushButton" name="reloadPushButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Reload Resources</string>
-     </property>
     </widget>
    </item>
   </layout>

--- a/qgis_hub_plugin/gui/resource_browser.ui
+++ b/qgis_hub_plugin/gui/resource_browser.ui
@@ -14,7 +14,17 @@
    <string>QGIS Hub Explorer</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
+   <item row="5" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QWidget" name="widget_4" native="true">
      <layout class="QHBoxLayout">
       <item>
@@ -237,13 +247,6 @@
            </property>
           </widget>
          </item>
-         <item row="10" column="0" colspan="2">
-          <widget class="QPushButton" name="pushButtonDownload">
-           <property name="text">
-            <string>Download</string>
-           </property>
-          </widget>
-         </item>
          <item row="8" column="0" colspan="2">
           <widget class="QCheckBox" name="checkBoxOpenDirectory">
            <property name="text">
@@ -251,10 +254,17 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="0" colspan="2">
+         <item row="10" column="0" colspan="2">
           <widget class="QPushButton" name="addQGISPushButton">
            <property name="text">
             <string>Add to QGIS</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0" colspan="2">
+          <widget class="QPushButton" name="pushButtonDownload">
+           <property name="text">
+            <string>Download</string>
            </property>
           </widget>
          </item>
@@ -262,16 +272,6 @@
        </widget>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
-     </property>
     </widget>
    </item>
    <item row="0" column="0" rowspan="2">
@@ -306,20 +306,6 @@
        <widget class="QLabel" name="labelResourceType">
         <property name="text">
          <string>Resource Type</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="labelReloadResources">
-        <property name="text">
-         <string>Reload Resources</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QToolButton" name="reloadToolButton">
-        <property name="text">
-         <string>...</string>
         </property>
        </widget>
       </item>
@@ -401,6 +387,19 @@
        </layout>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="reloadPushButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Reload Resources</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/qgis_hub_plugin/utilities/qgis_util.py
+++ b/qgis_hub_plugin/utilities/qgis_util.py
@@ -1,0 +1,16 @@
+from qgis.PyQt.QtCore import QCoreApplication, Qt
+from qgis.PyQt.QtWidgets import QApplication
+
+
+def show_busy_cursor(func):
+    def wrapper(*args, **kwargs):
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        QCoreApplication.processEvents()
+
+        try:
+            return func(*args, **kwargs)
+        finally:
+            QApplication.restoreOverrideCursor()
+            QCoreApplication.processEvents()
+
+    return wrapper


### PR DESCRIPTION
#38 
Moved the reload resources button to under the browser area, and use QPushButton instead.

#24 

- Show a busy cursor when retrieving the resources list, implement it as a decorator so that we can reuse it in other function/process
-  Show a success or failure message using QgsMessageBar

![image](https://github.com/qgis/QGIS-Hub-Plugin/assets/9210179/c96eaee7-7cc1-4d3c-a666-8f6b2cb527e2)
