### PR TITLE
Put the messages in the plugin window message bar

### DIFF
--- a/qgis_hub_plugin/gui/resource_browser.ui
+++ b/qgis_hub_plugin/gui/resource_browser.ui
@@ -14,7 +14,7 @@
    <string>QGIS Hub Explorer</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -24,7 +24,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QWidget" name="widget_4" native="true">
      <layout class="QHBoxLayout">
       <item>
@@ -293,10 +293,17 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0" rowspan="2">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="vlayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+    </layout>
+   </item>
+   <item row="1" column="0" rowspan="2">
     <widget class="QWidget" name="widget_3" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>


### PR DESCRIPTION
The success and warning messages are now displayed in the plugin window instead of the QGIS application window.

![image](https://github.com/qgis/QGIS-Hub-Plugin/assets/9210179/c554de6f-ceeb-48da-9b50-adf58d0ff96f)
