### PR TITLE
Updated logic to save download location in QgsSettings

### DIFF
--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -26,7 +26,12 @@ from qgis_hub_plugin.gui.constants import (
 )
 from qgis_hub_plugin.gui.resource_item import ResourceItem
 from qgis_hub_plugin.toolbelt import PlgLogger
-from qgis_hub_plugin.utilities.common import download_file, download_resource_thumbnail
+from qgis_hub_plugin.utilities.common import (
+    download_file,
+    download_resource_thumbnail,
+    read_settings,
+    store_settings,
+)
 from qgis_hub_plugin.utilities.qgis_util import show_busy_cursor
 
 UI_CLASS = uic.loadUiType(
@@ -217,10 +222,18 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         resource = self.selected_resource()
         file_extension = os.path.splitext(resource.file)[1]
 
+        # Set the default download location
+        default_download_location = "~/Downloads"
+
+        # Read the stored download location
+        download_location = read_settings("downloadLocation", default_download_location)
+
+        default_path = os.path.join(download_location, os.path.basename(resource.file))
+
         file_path = QFileDialog.getSaveFileName(
             self,
             self.tr("Save Resource"),
-            resource.file,
+            default_path,
             self.tr(
                 "All Files (*);;Geopackage (*.gpkg);;QGIS Model (*.model3);; ZIP Files (*.zip)"
             ),
@@ -239,6 +252,8 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
                     QDesktopServices.openUrl(
                         QUrl.fromLocalFile(str(Path(file_path).parent))
                     )
+
+                store_settings("downloadLocation", str(Path(file_path).parent))
 
     def add_resource_to_qgis(self):
         if self.selected_resource().resource_type == "Model":

--- a/qgis_hub_plugin/utilities/common.py
+++ b/qgis_hub_plugin/utilities/common.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from qgis.core import QgsApplication
+from qgis.core import QgsApplication, QgsSettings
 from qgis.PyQt.QtGui import QIcon
 
 from qgis_hub_plugin.__about__ import DIR_PLUGIN_ROOT
@@ -48,3 +48,16 @@ def download_resource_thumbnail(url: str, uuid: str):
     download_file(url, thumbnail_path)
     if thumbnail_path.exists():
         return thumbnail_path
+
+
+def store_settings(setting_key, setting_value):
+    settings = QgsSettings()
+    settings.setValue("QGISResourceHubPlugin/" + setting_key, setting_value)
+
+
+def read_settings(setting_key, default_value):
+    settings = QgsSettings()
+    stored_value = settings.value(
+        "QGISResourceHubPlugin/" + setting_key, defaultValue=default_value
+    )
+    return stored_value


### PR DESCRIPTION
#48 
Store the download location as a QgsSetting
Set the default to ~/Downloads 
Update it when the user changes the download location when downloading other resources
Don't update the download location when the user doesn't download it (e.g. add model to QGIS directly)