### PR TITLE
Update BASE_URL from 'plugins' to 'hub' - Fixes 404 error

### DIFF
--- a/qgis_hub_plugin/core/api_client.py
+++ b/qgis_hub_plugin/core/api_client.py
@@ -5,7 +5,7 @@ from qgis.core import QgsApplication
 
 from qgis_hub_plugin.utilities.common import download_file
 
-BASE_URL = "https://plugins.qgis.org/api/v1/resources/"
+BASE_URL = "https://hub.qgis.org/api/v1/resources/"
 
 
 def get_all_resources(force_update=False):


### PR DESCRIPTION
Since the Resources Hub now has it's own subdomain, the URL for the resource list needs to be updated in the plugin.

The 404 error in QGIS Hub Explorer:
```
qgis_hub_plugin.utilities.exception.DownloadError: File not found (404 error): https://plugins.qgis.org/api/v1/resources/?limit=1000&format=json
```