### PR TITLE
Add tree-based resource type filtering to replace checkboxes 

### DIFF
--- a/qgis_hub_plugin/gui/constants.py
+++ b/qgis_hub_plugin/gui/constants.py
@@ -14,3 +14,13 @@ class ResoureType:
     Geopackage = "Geopackage"
     Model3D = "3DModel"
     LayerDefinition = "LayerDefinition"
+
+
+# Resource type categories for display in the UI
+ResoureTypeCategories = {
+    "Styles": [ResoureType.Style],
+    "Geopackages": [ResoureType.Geopackage],
+    "Models": [ResoureType.Model],
+    "3D Models": [ResoureType.Model3D],
+    "Layer Definitions": [ResoureType.LayerDefinition]
+}

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -43,6 +43,7 @@ from qgis_hub_plugin.gui.constants import (
     NameRole,
     ResourceTypeRole,
     ResoureType,
+    ResoureTypeCategories,
 )
 from qgis_hub_plugin.gui.resource_item import AttributeSortingItem, ResourceItem
 from qgis_hub_plugin.toolbelt import PlgLogger, PlgOptionsManager
@@ -642,15 +643,6 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         # Create the root item
         self.treeWidgetCategories.invisibleRootItem()
         
-        # Add resource type categories
-        categories = {
-            "Styles": [ResoureType.Style],
-            "Geopackages": [ResoureType.Geopackage],
-            "Models": [ResoureType.Model],
-            "3D Models": [ResoureType.Model3D],
-            "Layer Definitions": [ResoureType.LayerDefinition]
-        }
-        
         self.tree_items = {}
         
         # Add the "All Types" root item
@@ -658,8 +650,8 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         all_types_item.setData(0, Qt.UserRole, "all")
         all_types_item.setExpanded(True)
         
-        # Add categories as children
-        for category_name, types in categories.items():
+        # Add categories as children - now using the constant from constants.py
+        for category_name, types in ResoureTypeCategories.items():
             category_item = QTreeWidgetItem(all_types_item, [category_name])
             category_item.setData(0, Qt.UserRole, types)
             self.tree_items[category_name] = category_item

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -661,6 +661,9 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         
         # Select the "All Types" item by default
         self.treeWidgetCategories.setCurrentItem(all_types_item)
+        
+        # Resize the tree widget to fit the content
+        self.resize_tree_widget()
 
     def on_tree_selection_changed(self):
         """
@@ -672,3 +675,45 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         
         # Update the resource filter based on tree selection
         self.update_resource_filter()
+
+    def resize_tree_widget(self):
+        """
+        Resize the tree widget to fit its content without extra blank space.
+        This adjusts the width of the categories tree based on the content.
+        """
+        if not self.treeWidgetCategories.topLevelItemCount():
+            return
+            
+        # Start with a small margin to prevent text from being right at the edge
+        max_width = 30
+        
+        # Check the width needed for each item
+        for i in range(self.treeWidgetCategories.topLevelItemCount()):
+            top_item = self.treeWidgetCategories.topLevelItem(i)
+            # Get width of top-level item
+            text_width = self.treeWidgetCategories.fontMetrics().horizontalAdvance(top_item.text(0))
+            max_width = max(max_width, text_width)
+            
+            # Check width for child items
+            for j in range(top_item.childCount()):
+                child_item = top_item.child(j)
+                # Child items need indentation, so add some extra width
+                child_text_width = self.treeWidgetCategories.fontMetrics().horizontalAdvance(child_item.text(0)) + 20
+                max_width = max(max_width, child_text_width)
+        
+        # Add some padding for better appearance
+        max_width += 40
+        
+        # Ensure the width isn't too small
+        max_width = max(max_width, 100)
+        
+        # Set only the minimum width to allow QSplitter to be resizable
+        self.widget_category_section.setMinimumWidth(max_width)
+        
+        # Set initial width of the QSplitter at the optimal size
+        sizes = self.splitter_categories_resources.sizes()
+        if sizes:
+            # Calculate the total width of the splitter
+            total_width = sum(sizes)
+            # Set initial positions - give the category section its optimal width
+            self.splitter_categories_resources.setSizes([max_width, total_width - max_width])

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -639,9 +639,6 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         # Clear the tree widget
         self.treeWidgetCategories.clear()
         
-        # Set up the header
-        self.treeWidgetCategories.setHeaderLabel("Resource Types")
-        
         # Create the root item
         self.treeWidgetCategories.invisibleRootItem()
         

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -87,8 +87,8 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         # Resources
         self.resources = []
         self.selected_resource = None
-        self.checkbox_states = {}
-        self.update_checkbox_states()
+        self.filter_states = {}
+        self.update_filter_states()
 
         # Setup resource model and proxy model first
         self.resource_model = QStandardItemModel()
@@ -248,10 +248,10 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         self.resize_columns()
         self.update_title_bar()
 
-    def update_checkbox_states(self):
+    def update_filter_states(self):
         """
         Create a dictionary with resource types and their filter states.
-        This method is maintained for compatibility but now gets states from the tree selection.
+        This method gets filter states from the tree selection.
         """
         selected_items = self.treeWidgetCategories.selectedItems()
         selected_types = None
@@ -262,7 +262,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         # Default to all types selected if nothing is selected or "all" is selected
         is_all_selected = not selected_types or selected_types == "all"
         
-        self.checkbox_states = {
+        self.filter_states = {
             ResoureType.Geopackage: is_all_selected or (selected_types and ResoureType.Geopackage in selected_types),
             ResoureType.Style: is_all_selected or (selected_types and ResoureType.Style in selected_types),
             ResoureType.Model: is_all_selected or (selected_types and ResoureType.Model in selected_types),
@@ -273,23 +273,23 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
     def update_resource_filter(self):
         current_text = self.lineEditSearch.text()
 
-        self.update_checkbox_states()
+        self.update_filter_states()
 
         filter_regexp_parts = ["NONE"]
-        for resource_type, checked in self.checkbox_states.items():
+        for resource_type, checked in self.filter_states.items():
             if checked:
                 filter_regexp_parts.append(resource_type)
 
         filter_regexp = QRegExp("|".join(filter_regexp_parts), Qt.CaseInsensitive)
         self.proxy_model.setFilterRegExp(filter_regexp)
         self.proxy_model.setRolesToFilter([ResourceTypeRole])
-        self.proxy_model.setCheckboxStates(self.checkbox_states)
+        self.proxy_model.setCheckboxStates(self.filter_states)
         self.on_filter_text_changed(current_text)
 
     def on_filter_text_changed(self, text):
         self.proxy_model.setFilterRegExp(QRegExp(text, Qt.CaseInsensitive))
         self.proxy_model.setRolesToFilter([NameRole, CreatorRole])
-        self.proxy_model.setCheckboxStates(self.checkbox_states)
+        self.proxy_model.setCheckboxStates(self.filter_states)
 
         self.update_title_bar()
 
@@ -679,7 +679,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         Update the resource filter accordingly.
         """
         # Update the checkbox states dictionary (which is now just for filtering logic)
-        self.update_checkbox_states()
+        self.update_filter_states()
         
         # Update the resource filter based on tree selection
         self.update_resource_filter()

--- a/qgis_hub_plugin/gui/resource_browser.ui
+++ b/qgis_hub_plugin/gui/resource_browser.ui
@@ -101,10 +101,10 @@
              <bool>true</bool>
             </property>
             <property name="headerHidden">
-             <bool>false</bool>
+             <bool>true</bool>
             </property>
             <attribute name="headerVisible">
-             <bool>true</bool>
+             <bool>false</bool>
             </attribute>
             <attribute name="headerStretchLastSection">
              <bool>true</bool>
@@ -404,7 +404,8 @@
          <item row="3" column="1">
           <widget class="QLabel" name="labelSubtype">
            <property name="text">
-            <string>Subtype</string>           </property>
+            <string>Subtype</string>
+           </property>
            <property name="wordWrap">
             <bool>true</bool>
            </property>

--- a/qgis_hub_plugin/gui/resource_browser.ui
+++ b/qgis_hub_plugin/gui/resource_browser.ui
@@ -91,11 +91,11 @@
           </property>
           <item>
            <widget class="QTreeWidget" name="treeWidgetCategories">
-            <property name="minimumSize">
-             <size>
-              <width>150</width>
-              <height>0</height>
-             </size>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
             <property name="alternatingRowColors">
              <bool>true</bool>

--- a/qgis_hub_plugin/gui/resource_browser.ui
+++ b/qgis_hub_plugin/gui/resource_browser.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1319</width>
-    <height>773</height>
+    <width>913</width>
+    <height>658</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,7 +33,7 @@
    </item>
    <item row="3" column="0">
     <widget class="QWidget" name="widget_4" native="true">
-     <layout class="QHBoxLayout">
+     <layout class="QHBoxLayout" name="horizontalLayout_MainArea">
       <property name="spacing">
        <number>3</number>
       </property>
@@ -50,8 +50,65 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QWidget" name="widget_5" native="true">
-        <layout class="QVBoxLayout" name="verticalLayout_3">
+       <widget class="QWidget" name="widget_category_section" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>300</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_Categories">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QTreeWidget" name="treeWidgetCategories">
+           <property name="alternatingRowColors">
+            <bool>true</bool>
+           </property>
+           <property name="headerHidden">
+            <bool>false</bool>
+           </property>
+           <attribute name="headerVisible">
+            <bool>true</bool>
+           </attribute>
+           <attribute name="headerStretchLastSection">
+            <bool>true</bool>
+           </attribute>
+           <column>
+            <property name="text">
+             <string notr="true">1</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="widget_resource_view" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_ResourceView">
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -75,7 +132,7 @@
               <widget class="QListView" name="listViewResources">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                 <horstretch>0</horstretch>
+                 <horstretch>1</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
@@ -102,6 +159,12 @@
             <layout class="QVBoxLayout" name="verticalLayout_5">
              <item>
               <widget class="QTreeView" name="treeViewResources">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
                <property name="editTriggers">
                 <set>QAbstractItemView::NoEditTriggers</set>
                </property>
@@ -206,7 +269,7 @@
       <item>
        <widget class="QGroupBox" name="groupBoxPreview">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -467,115 +530,6 @@
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QLineEdit" name="lineEditSearch"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelResourceType">
-        <property name="text">
-         <string>Resource Type</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QWidget" name="widget_2" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <property name="leftMargin">
-          <number>9</number>
-         </property>
-         <property name="topMargin">
-          <number>9</number>
-         </property>
-         <property name="rightMargin">
-          <number>9</number>
-         </property>
-         <property name="bottomMargin">
-          <number>9</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="checkBoxStyle">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Style</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="checkBoxGeopackage">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Geopackage</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-           <property name="tristate">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="checkBoxModel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Model</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="checkBoxModel3D">
-           <property name="text">
-            <string>3D Model</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="checkBoxLayerDefinition">
-           <property name="text">
-            <string>QGIS Layer</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
          </item>
         </layout>
        </widget>

--- a/qgis_hub_plugin/gui/resource_browser.ui
+++ b/qgis_hub_plugin/gui/resource_browser.ui
@@ -33,6 +33,12 @@
    </item>
    <item row="3" column="0">
     <widget class="QWidget" name="widget_4" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <layout class="QHBoxLayout" name="horizontalLayout_MainArea">
       <property name="spacing">
        <number>3</number>
@@ -50,220 +56,232 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QWidget" name="widget_category_section" native="true">
+       <widget class="QSplitter" name="splitter_categories_resources">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>300</width>
-          <height>16777215</height>
-         </size>
+        <property name="childrenCollapsible">
+         <bool>false</bool>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_Categories">
-         <property name="leftMargin">
-          <number>0</number>
+        <widget class="QWidget" name="widget_category_section" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QTreeWidget" name="treeWidgetCategories">
-           <property name="alternatingRowColors">
-            <bool>true</bool>
-           </property>
-           <property name="headerHidden">
-            <bool>false</bool>
-           </property>
-           <attribute name="headerVisible">
-            <bool>true</bool>
-           </attribute>
-           <attribute name="headerStretchLastSection">
-            <bool>true</bool>
-           </attribute>
-           <column>
-            <property name="text">
-             <string notr="true">1</string>
+         <layout class="QVBoxLayout" name="verticalLayout_Categories">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QTreeWidget" name="treeWidgetCategories">
+            <property name="minimumSize">
+             <size>
+              <width>150</width>
+              <height>0</height>
+             </size>
             </property>
-           </column>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="widget_resource_view" native="true">
-        <layout class="QVBoxLayout" name="verticalLayout_ResourceView">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QStackedWidget" name="viewStackedWidget">
-           <property name="currentIndex">
-            <number>0</number>
-           </property>
-           <widget class="QWidget" name="gridViewPage">
-            <layout class="QVBoxLayout" name="verticalLayout_2">
-             <item>
-              <widget class="QListView" name="listViewResources">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                 <horstretch>1</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="sizeAdjustPolicy">
-                <enum>QAbstractScrollArea::AdjustIgnored</enum>
-               </property>
-               <property name="editTriggers">
-                <set>QAbstractItemView::NoEditTriggers</set>
-               </property>
-               <property name="resizeMode">
-                <enum>QListView::Adjust</enum>
-               </property>
-               <property name="viewMode">
-                <enum>QListView::IconMode</enum>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-           <widget class="QWidget" name="iconViewPage">
-            <layout class="QVBoxLayout" name="verticalLayout_5">
-             <item>
-              <widget class="QTreeView" name="treeViewResources">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                 <horstretch>1</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="editTriggers">
-                <set>QAbstractItemView::NoEditTriggers</set>
-               </property>
-               <property name="alternatingRowColors">
-                <bool>true</bool>
-               </property>
-               <property name="sortingEnabled">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </widget>
-         </item>
-         <item>
-          <widget class="QWidget" name="widget_6" native="true">
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <property name="leftMargin">
-             <number>9</number>
+            <property name="alternatingRowColors">
+             <bool>true</bool>
             </property>
-            <property name="topMargin">
+            <property name="headerHidden">
+             <bool>false</bool>
+            </property>
+            <attribute name="headerVisible">
+             <bool>true</bool>
+            </attribute>
+            <attribute name="headerStretchLastSection">
+             <bool>true</bool>
+            </attribute>
+            <column>
+             <property name="text">
+              <string notr="true">Resource Types</string>
+             </property>
+            </column>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="widget_resource_view" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>1</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_ResourceView">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QStackedWidget" name="viewStackedWidget">
+            <property name="currentIndex">
              <number>0</number>
             </property>
-            <property name="rightMargin">
-             <number>9</number>
-            </property>
-            <item>
-             <widget class="QPushButton" name="reloadPushButton">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Update Resources</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QSlider" name="iconSizeSlider">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QToolButton" name="iconViewToolButton">
-              <property name="text">
-               <string>...</string>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-              <attribute name="buttonGroup">
-               <string notr="true">buttonGroup</string>
-              </attribute>
-             </widget>
-            </item>
-            <item>
-             <widget class="QToolButton" name="listViewToolButton">
-              <property name="text">
-               <string>...</string>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
-              </property>
-              <attribute name="buttonGroup">
-               <string notr="true">buttonGroup</string>
-              </attribute>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
+            <widget class="QWidget" name="gridViewPage">
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <item>
+               <widget class="QListView" name="listViewResources">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                  <horstretch>1</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="sizeAdjustPolicy">
+                 <enum>QAbstractScrollArea::AdjustIgnored</enum>
+                </property>
+                <property name="editTriggers">
+                 <set>QAbstractItemView::NoEditTriggers</set>
+                </property>
+                <property name="resizeMode">
+                 <enum>QListView::Adjust</enum>
+                </property>
+                <property name="viewMode">
+                 <enum>QListView::IconMode</enum>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="iconViewPage">
+             <layout class="QVBoxLayout" name="verticalLayout_5">
+              <item>
+               <widget class="QTreeView" name="treeViewResources">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                  <horstretch>1</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="editTriggers">
+                 <set>QAbstractItemView::NoEditTriggers</set>
+                </property>
+                <property name="alternatingRowColors">
+                 <bool>true</bool>
+                </property>
+                <property name="sortingEnabled">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="widget_6" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <property name="leftMargin">
+              <number>9</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>9</number>
+             </property>
+             <item>
+              <widget class="QPushButton" name="reloadPushButton">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Update Resources</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QSlider" name="iconSizeSlider">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="iconViewToolButton">
+               <property name="text">
+                <string>...</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+               <property name="autoRaise">
+                <bool>true</bool>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroup</string>
+               </attribute>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="listViewToolButton">
+               <property name="text">
+                <string>...</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="autoRaise">
+                <bool>true</bool>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroup</string>
+               </attribute>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
       <item>
@@ -386,8 +404,7 @@
          <item row="3" column="1">
           <widget class="QLabel" name="labelSubtype">
            <property name="text">
-            <string>Subtype</string>
-           </property>
+            <string>Subtype</string>           </property>
            <property name="wordWrap">
             <bool>true</bool>
            </property>


### PR DESCRIPTION

## Description

### Changes
- Replaced checkbox-based resource type filtering with `QTreeWidget` for a more intuitive UI  
- Implemented hierarchical structure with **"All Types"** as parent and specific resource types as children  
- Updated filtering logic to work with tree selection instead of checkboxes  
- Maintained all existing filtering functionality  

### Benefits
- More organized and scalable interface for resource type filtering  
- Better visual hierarchy making filtering more intuitive  
- Easier to extend with new resource types in the future  
- Cleaner UI with reduced clutter  

### Screenshots

![image](https://github.com/user-attachments/assets/43edeb36-83cf-45a9-a867-6434f5424cbc)


This change improves the UX while preserving all existing functionality of the resource browser.

#106 
