### PR TITLE
Display actual import error instead of success message for processing scripts

### DIFF
--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -430,10 +430,12 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         pretty_upload_date = resource.upload_date.strftime("%d %B %Y").lstrip("0")
         self.labelUploaded.setText(pretty_upload_date)
         
-        # Show dependencies if they exist (for Models)
+        # Show dependencies if they exist (for Models and Processing Scripts)
         if hasattr(self, 'labelDependencies') and hasattr(self, 'labelDependenciesLabel'):
             # Convert dependencies to boolean - check if it's not None and not empty
-            has_dependencies = resource.resource_type == ResoureType.Model and resource.dependencies is not None and resource.dependencies != ""
+            has_dependencies = (resource.resource_type in [ResoureType.Model, ResoureType.ProcessingScripts] and 
+                              resource.dependencies is not None and 
+                              resource.dependencies != "")
             self.labelDependenciesLabel.setVisible(has_dependencies)
             self.labelDependencies.setVisible(has_dependencies)
             if has_dependencies:

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -420,7 +420,9 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
 
         # Description
         self.labelName.setText(resource.name)
-        self.labelType.setText(resource.resource_type)
+        # Use a user-friendly display name for the resource type based on its category
+        display_type = self.get_type_display_name(resource.resource_type)
+        self.labelType.setText(display_type)
         self.labelSubtype.setVisible(bool(resource.resource_subtype))
         self.labelSubtypeLabel.setVisible(bool(resource.resource_subtype))
         if resource.resource_subtype:
@@ -1023,3 +1025,16 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
             category_name = f"{new_type}s"  # Simple pluralization
             if category_name not in ResoureTypeCategories:
                 ResoureTypeCategories[category_name] = [new_type]
+
+    def get_type_display_name(self, resource_type):
+        """
+        Get a user-friendly display name for a resource type based on its category.
+        """
+        # Look through ResoureTypeCategories to find the category containing this type
+        for category_name, types in ResoureTypeCategories.items():
+            if resource_type in types:
+                # Return the category name as is
+                return category_name
+        
+        # If not found, return the resource type as is
+        return resource_type


### PR DESCRIPTION
## Description
When adding a processing script that has missing dependencies, the plugin currently shows a success message even when the script fails to load. This PR modifies the behavior to:

1. Check if the script was successfully loaded by monitoring algorithm changes
2. Attempt to import the script to catch any import errors
3. Show the actual error message to users (e.g., "No module named 'pcraster'") 
4. Delete the failed script file to avoid having invalid scripts in the processing directory

## Screenshots
![image](https://github.com/user-attachments/assets/1137683a-f68e-4c42-a913-cc8cf0ad1467)

Fix #111 