### PR TITLE
Qt6/QGIS 4 support: tests, fixes, and CI matrix (draft, supersedes #145)

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -42,4 +42,3 @@ jobs:
           flake8 ${{ env.PROJECT_FOLDER }} --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings.
           flake8 ${{ env.PROJECT_FOLDER }} --count --exit-zero --statistics
-

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -56,4 +56,3 @@ jobs:
         --github-token ${{ secrets.GITHUB_TOKEN }}
         --allow-uncommitted-changes
         --create-plugin-repo
-

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -49,11 +49,20 @@ jobs:
           fail_ci_if_error: false
 
   tests-qgis:
-    name: Integration Tests (QGIS)
+    name: Integration Tests (${{ matrix.qgis-image }})
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - qgis-image: qgis/qgis:release-3_34
+            qt-version: Qt5
+          - qgis-image: qgis/qgis:4.0
+            qt-version: Qt6
+
     container:
-      image: qgis/qgis:release-3_34
+      image: ${{ matrix.qgis-image }}
       options: --user root
 
     env:
@@ -89,5 +98,5 @@ jobs:
         if: success()
         with:
           files: ./coverage.xml
-          flags: integration
+          flags: integration-${{ matrix.qt-version }}
           fail_ci_if_error: false

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -58,8 +58,10 @@ jobs:
         include:
           - qgis-image: qgis/qgis:release-3_34
             qt-version: Qt5
+            pip-extra-args: ""
           - qgis-image: qgis/qgis:4.0
             qt-version: Qt6
+            pip-extra-args: "--break-system-packages"
 
     container:
       image: ${{ matrix.qgis-image }}
@@ -82,8 +84,8 @@ jobs:
 
       - name: Install Python requirements
         run: |
-          python3 -m pip install --break-system-packages --upgrade pip setuptools wheel
-          python3 -m pip install --break-system-packages -r requirements/testing.txt
+          python3 -m pip install ${{ matrix.pip-extra-args }} --upgrade pip setuptools wheel
+          python3 -m pip install ${{ matrix.pip-extra-args }} -r requirements/testing.txt
 
       - name: Verify QGIS Python is available
         run: |

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -84,7 +84,6 @@ jobs:
 
       - name: Install Python requirements
         run: |
-          python3 -m pip install ${{ matrix.pip-extra-args }} --upgrade pip setuptools wheel
           python3 -m pip install ${{ matrix.pip-extra-args }} -r requirements/testing.txt
 
       - name: Verify QGIS Python is available

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -82,8 +82,8 @@ jobs:
 
       - name: Install Python requirements
         run: |
-          python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install -r requirements/testing.txt
+          python3 -m pip install --break-system-packages --upgrade pip setuptools wheel
+          python3 -m pip install --break-system-packages -r requirements/testing.txt
 
       - name: Verify QGIS Python is available
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
           - "--py39-plus"
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 25.1.0
     hooks:
       - id: black
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,4 +18,3 @@ Make sure your code *roughly* follows [PEP-8](https://www.python.org/dev/peps/pe
 - formatting: [black](https://black.readthedocs.io/) is used to automatically format the code without debate.
 - sorted imports: [isort](https://pycqa.github.io/isort/) is used to sort imports
 - static analisis: [flake8](https://flake8.pycqa.org/en/latest/) is used to catch some dizziness and keep the source code healthy.
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 #!python3
 
 """
-    Configuration for project documentation using Sphinx.
+Configuration for project documentation using Sphinx.
 """
 
 # standard

--- a/qgis_hub_plugin/core/custom_filter_proxy.py
+++ b/qgis_hub_plugin/core/custom_filter_proxy.py
@@ -82,7 +82,7 @@ class MultiRoleFilterProxyModel(QSortFilterProxyModel):
         # Text search filtering
         for role in self.roles_to_filter:
             data = model.data(index, role)
-            if data and self.filterRegExp().indexIn(str(data)) != -1:
+            if data and self.filterRegularExpression().match(str(data)).hasMatch():
                 return True
 
         # If we're filtering by roles and nothing matched, hide the item

--- a/qgis_hub_plugin/gui/constants.py
+++ b/qgis_hub_plugin/gui/constants.py
@@ -1,11 +1,11 @@
 from qgis.PyQt.QtCore import Qt
 
 # Resource Item Data
-ResourceTypeRole = Qt.UserRole + 1
-NameRole = Qt.UserRole + 2
-CreatorRole = Qt.UserRole + 3
-SortingRole = Qt.UserRole + 4
-ResourceSubtypeRole = Qt.UserRole + 5
+ResourceTypeRole = Qt.ItemDataRole.UserRole + 1
+NameRole = Qt.ItemDataRole.UserRole + 2
+CreatorRole = Qt.ItemDataRole.UserRole + 3
+SortingRole = Qt.ItemDataRole.UserRole + 4
+ResourceSubtypeRole = Qt.ItemDataRole.UserRole + 5
 
 
 # Type of resources, based on the QGIS Hub API

--- a/qgis_hub_plugin/gui/dlg_settings.py
+++ b/qgis_hub_plugin/gui/dlg_settings.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from qgis.core import QgsApplication
 from qgis.gui import QgsOptionsPageWidget, QgsOptionsWidgetFactory
 from qgis.PyQt import uic
-from qgis.PyQt.Qt import QUrl
+from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtGui import QDesktopServices, QIcon
 
 # project

--- a/qgis_hub_plugin/gui/dlg_settings.py
+++ b/qgis_hub_plugin/gui/dlg_settings.py
@@ -14,6 +14,7 @@ from qgis.gui import QgsOptionsPageWidget, QgsOptionsWidgetFactory
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtGui import QDesktopServices, QIcon
+from qgis.PyQt.QtWidgets import QMessageBox
 
 # project
 from qgis_hub_plugin.__about__ import (
@@ -25,6 +26,7 @@ from qgis_hub_plugin.__about__ import (
 )
 from qgis_hub_plugin.toolbelt import PlgLogger, PlgOptionsManager
 from qgis_hub_plugin.toolbelt.preferences import PlgSettingsStructure
+from qgis_hub_plugin.utilities.common import clear_cache
 
 # ############################################################################
 # ########## Globals ###############
@@ -69,6 +71,11 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
         self.btn_reset.setIcon(QIcon(QgsApplication.iconPath("mActionUndo.svg")))
         self.btn_reset.pressed.connect(self.reset_settings)
 
+        self.btn_clear_cache.setIcon(
+            QIcon(QgsApplication.iconPath("mActionDeleteSelected.svg"))
+        )
+        self.btn_clear_cache.pressed.connect(self.clear_cache)
+
         # load previously saved settings
         self.load_settings()
 
@@ -98,6 +105,44 @@ class ConfigOptionsPage(FORM_CLASS, QgsOptionsPageWidget):
         # global
         self.opt_debug.setChecked(settings.debug_mode)
         self.lbl_version_saved_value.setText(settings.version)
+
+    def clear_cache(self):
+        """Delete the cached API response and all cached thumbnails."""
+        confirm = QMessageBox.question(
+            self,
+            self.tr("Clear QGIS Hub cache"),
+            self.tr(
+                "This will delete the cached resource list and all downloaded "
+                "thumbnails. They will be re-downloaded the next time you open "
+                "the resource browser.\n\nContinue?"
+            ),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+
+        try:
+            response_removed, thumbnails_removed = clear_cache()
+        except OSError as exc:
+            QMessageBox.warning(
+                self,
+                self.tr("Clear QGIS Hub cache"),
+                self.tr("Failed to clear cache: {err}").format(err=exc),
+            )
+            return
+
+        QMessageBox.information(
+            self,
+            self.tr("Clear QGIS Hub cache"),
+            self.tr(
+                "Cache cleared.\n\nResource list removed: {resp}\n"
+                "Thumbnails removed: {n}"
+            ).format(
+                resp=self.tr("yes") if response_removed else self.tr("no"),
+                n=thumbnails_removed,
+            ),
+        )
 
     def reset_settings(self):
         """Reset settings to default values (set in preferences.py module)."""

--- a/qgis_hub_plugin/gui/dlg_settings.ui
+++ b/qgis_hub_plugin/gui/dlg_settings.ui
@@ -170,6 +170,28 @@
                             </widget>
                         </item>
                         <item row="3" column="0" colspan="2">
+                            <widget class="QPushButton" name="btn_clear_cache">
+                                <property name="minimumSize">
+                                    <size>
+                                        <width>200</width>
+                                        <height>25</height>
+                                    </size>
+                                </property>
+                                <property name="maximumSize">
+                                    <size>
+                                        <width>16777215</width>
+                                        <height>30</height>
+                                    </size>
+                                </property>
+                                <property name="toolTip">
+                                    <string>Delete the cached resource list and all downloaded thumbnails.</string>
+                                </property>
+                                <property name="text">
+                                    <string>Clear cache (resources and thumbnails)</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="4" column="0" colspan="2">
                             <widget class="QPushButton" name="btn_reset">
                                 <property name="minimumSize">
                                     <size>

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -200,7 +200,9 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         progress = QProgressBar()
         progress.setMaximum(total)
         progress.setValue(0)
-        progress.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        progress.setAlignment(
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+        )
         widget.layout().addWidget(progress)
         message_bar.pushWidget(widget, Qgis.Info)
         return progress, widget

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -18,7 +18,7 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtCore import (
     QByteArray,
     QItemSelectionModel,
-    QRegExp,
+    QRegularExpression,
     QSize,
     Qt,
     QUrl,
@@ -93,7 +93,9 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
 
         # Message bar
         self.message_bar = QgsMessageBar(self)
-        self.message_bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        self.message_bar.setSizePolicy(
+            QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
+        )
         self.vlayout.insertWidget(0, self.message_bar)
 
         # Resources
@@ -342,14 +344,21 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
             if checked:
                 filter_regexp_parts.append(resource_type)
 
-        filter_regexp = QRegExp("|".join(filter_regexp_parts), Qt.CaseInsensitive)
-        self.proxy_model.setFilterRegExp(filter_regexp)
+        filter_regexp = QRegularExpression(
+            "|".join(filter_regexp_parts),
+            QRegularExpression.PatternOption.CaseInsensitiveOption,
+        )
+        self.proxy_model.setFilterRegularExpression(filter_regexp)
         self.proxy_model.setRolesToFilter([ResourceTypeRole])
         self.proxy_model.setCheckboxStates(self.filter_states)
         self.on_filter_text_changed(current_text)
 
     def on_filter_text_changed(self, text):
-        self.proxy_model.setFilterRegExp(QRegExp(text, Qt.CaseInsensitive))
+        self.proxy_model.setFilterRegularExpression(
+            QRegularExpression(
+                text, QRegularExpression.PatternOption.CaseInsensitiveOption
+            )
+        )
         self.proxy_model.setRolesToFilter([NameRole, CreatorRole])
         self.proxy_model.setCheckboxStates(self.filter_states)
 

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -886,7 +886,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         selected_indexes = self.treeViewResources.selectionModel().selectedIndexes()
         if selected_indexes:
             self.listViewResources.selectionModel().select(
-                selected_indexes[0], QItemSelectionModel.ClearAndSelect
+                selected_indexes[0], QItemSelectionModel.SelectionFlag.ClearAndSelect
             )
             self.listViewResources.setCurrentIndex(selected_indexes[0])
 
@@ -901,7 +901,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         selected_indexes = self.listViewResources.selectionModel().selectedIndexes()
         if selected_indexes:
             self.treeViewResources.selectionModel().select(
-                selected_indexes[0], QItemSelectionModel.ClearAndSelect
+                selected_indexes[0], QItemSelectionModel.SelectionFlag.ClearAndSelect
             )
             self.treeViewResources.setCurrentIndex(selected_indexes[0])
 

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -32,6 +32,7 @@ from qgis.PyQt.QtWidgets import (
     QFormLayout,
     QGraphicsPixmapItem,
     QGraphicsScene,
+    QProgressBar,
     QSizePolicy,
     QTreeWidgetItem,
 )
@@ -53,6 +54,7 @@ from qgis_hub_plugin.utilities.common import (
     QGIS_HUB_DIR,
     download_file,
     download_resource_thumbnail,
+    is_resource_thumbnail_cached,
     normalize_resource_subtypes,
 )
 from qgis_hub_plugin.utilities.exception import DownloadError
@@ -182,6 +184,32 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
     def show_warning_message(self, text):
         return self.message_bar.pushMessage(self.tr("Warning"), text, Qgis.Warning, 5)
 
+    def _start_thumbnail_progress(self, total):
+        """Show a progress bar in the QGIS main message bar for the initial
+        thumbnail download. Returns (progress_bar, progress_widget) or
+        (None, None) when no progress should be shown (no iface or nothing
+        to download)."""
+        if total <= 0 or self.iface is None:
+            return None, None
+
+        message_bar = self.iface.messageBar()
+        widget = message_bar.createMessage(
+            self.tr("QGIS Hub"),
+            self.tr("Downloading {n} thumbnails…").format(n=total),
+        )
+        progress = QProgressBar()
+        progress.setMaximum(total)
+        progress.setValue(0)
+        progress.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        widget.layout().addWidget(progress)
+        message_bar.pushWidget(widget, Qgis.Info)
+        return progress, widget
+
+    def _finish_thumbnail_progress(self, widget):
+        if widget is None or self.iface is None:
+            return
+        self.iface.messageBar().popWidget(widget)
+
     def store_setting(self):
         # Download directory check box
         self.plg_settings.set_value_from_key(
@@ -254,7 +282,21 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         self.resource_model.setHorizontalHeaderLabels(
             ["Name", "Creator", "Download", "Uploaded"]
         )
+
+        missing_thumbnail_uuids = {
+            r.get("uuid")
+            for r in self.resources
+            if r.get("thumbnail")
+            and not r.get("thumbnail").endswith("qgis-icon-32x32.png")
+            and not is_resource_thumbnail_cached(r.get("thumbnail"), r.get("uuid"))
+        }
+        progress_bar, progress_widget = self._start_thumbnail_progress(
+            len(missing_thumbnail_uuids)
+        )
+        downloaded = 0
+
         for resource in self.resources:
+            needs_download = resource.get("uuid") in missing_thumbnail_uuids
             item = ResourceItem(resource)
             author = QStandardItem(item.creator)
             download_count = AttributeSortingItem(
@@ -263,6 +305,13 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
             pretty_date = item.upload_date.strftime("%d %B %Y").lstrip("0")
             upload_date = AttributeSortingItem(pretty_date, item.upload_date)
             self.resource_model.appendRow([item, author, download_count, upload_date])
+
+            if progress_bar is not None and needs_download:
+                downloaded += 1
+                progress_bar.setValue(downloaded)
+                QgsApplication.processEvents()
+
+        self._finish_thumbnail_progress(progress_widget)
 
         if force_update:
             self.show_success_message("Successfully update the resources")

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -120,7 +120,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         self.populate_resources()
 
         # Tooltip
-        self.buttonBox.button(QDialogButtonBox.Help).setToolTip(
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Help).setToolTip(
             self.tr("Open the help page")
         )
         self.listViewToolButton.setToolTip(self.tr("List view"))
@@ -153,7 +153,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         self.addQGISPushButton.clicked.connect(self.add_resource_to_qgis)
         self.listViewToolButton.toggled.connect(self.show_list_view)
         self.iconViewToolButton.toggled.connect(self.show_icon_view)
-        self.buttonBox.button(QDialogButtonBox.Help).clicked.connect(
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Help).clicked.connect(
             partial(QDesktopServices.openUrl, QUrl(__uri_homepage__))
         )
         self.reloadPushButton.clicked.connect(
@@ -283,7 +283,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         selected_data = None
 
         if selected_items:
-            selected_data = selected_items[0].data(0, Qt.UserRole)
+            selected_data = selected_items[0].data(0, Qt.ItemDataRole.UserRole)
 
         # Default to all types selected if nothing is selected or "all" is selected
         is_all_selected = not selected_data or selected_data == "all"
@@ -444,7 +444,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
 
             self.graphicsViewPreview.scene().clear()
             self.graphicsViewPreview.scene().addItem(item)
-            self.graphicsViewPreview.fitInView(item, Qt.KeepAspectRatio)
+            self.graphicsViewPreview.fitInView(item, Qt.AspectRatioMode.KeepAspectRatio)
 
         # Description
         self.labelName.setText(resource.name)
@@ -869,7 +869,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         all_types_item = QTreeWidgetItem(
             self.treeWidgetCategories, [f"All Types ({total_resources})"]
         )
-        all_types_item.setData(0, Qt.UserRole, "all")
+        all_types_item.setData(0, Qt.ItemDataRole.UserRole, "all")
         all_types_item.setExpanded(True)
         # Make "All Types" bold
         font = all_types_item.font(0)
@@ -909,7 +909,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
                 category_item = QTreeWidgetItem(
                     all_types_item, [f"{category_name} ({category_count})"]
                 )
-                category_item.setData(0, Qt.UserRole, types)
+                category_item.setData(0, Qt.ItemDataRole.UserRole, types)
                 # Make category names bold
                 font = category_item.font(0)
                 font.setBold(True)
@@ -946,7 +946,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
                             ],  # Assuming one type per category for simplicity
                             "subtype": subtype,
                         }
-                        subtype_item.setData(0, Qt.UserRole, subtype_data)
+                        subtype_item.setData(0, Qt.ItemDataRole.UserRole, subtype_data)
 
                         # Add the subtype to the tree_items dictionary for later reference
                         self.tree_items[f"{category_name}:{subtype}"] = subtype_item
@@ -958,7 +958,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
             category_item = QTreeWidgetItem(
                 all_types_item, [f"{category_name} ({count})"]
             )
-            category_item.setData(0, Qt.UserRole, [unknown_type])
+            category_item.setData(0, Qt.ItemDataRole.UserRole, [unknown_type])
             # Make dynamic category names bold
             font = category_item.font(0)
             font.setBold(True)
@@ -990,7 +990,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
 
                     # Store the resource type and subtype for filtering
                     subtype_data = {"type": unknown_type, "subtype": subtype}
-                    subtype_item.setData(0, Qt.UserRole, subtype_data)
+                    subtype_item.setData(0, Qt.ItemDataRole.UserRole, subtype_data)
 
                     # Add the subtype to the tree_items dictionary
                     self.tree_items[f"{category_name}:{subtype}"] = subtype_item
@@ -1147,10 +1147,10 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
         # Find the row for the previousLabel in the layout
         row = -1  # Default to -1 if the label is not found
         for i in range(layout.rowCount()):
-            layoutItem_label = layout.itemAt(i, QFormLayout.LabelRole)
+            layoutItem_label = layout.itemAt(i, QFormLayout.ItemRole.LabelRole)
             if not layoutItem_label:
                 continue
-            label_widget = layout.itemAt(i, QFormLayout.LabelRole).widget()
+            label_widget = layout.itemAt(i, QFormLayout.ItemRole.LabelRole).widget()
             if label_widget == previousLabel:
                 row = i
                 break

--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -776,6 +776,24 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
                     )
                     module = importlib.util.module_from_spec(spec)
                     spec.loader.exec_module(module)
+                except ModuleNotFoundError as exc:
+                    if exc.name == "PyQt5":
+                        self.show_error_message(
+                            self.tr(
+                                f"Script “{resource.name}” was written for "
+                                "QGIS 3 (PyQt5) and is not compatible with "
+                                "this QGIS version (PyQt6). The script was "
+                                f"saved to {file_path} but cannot be loaded "
+                                "until it is updated to import from qgis.PyQt."
+                            )
+                        )
+                    else:
+                        self.show_error_message(
+                            self.tr(
+                                f"Script downloaded to {file_path}, "
+                                f"but a required module is missing:\n{exc}"
+                            )
+                        )
                 except Exception as exc:  # noqa: BLE001
                     self.show_error_message(
                         self.tr(
@@ -849,6 +867,7 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
 
     def update_icon_size(self, size):
         self.listViewResources.setIconSize(QSize(size, size))
+        self.listViewResources.setGridSize(QSize(size + 20, size + 40))
 
     def setup_resource_type_tree(self):
         """

--- a/qgis_hub_plugin/gui/resource_item.py
+++ b/qgis_hub_plugin/gui/resource_item.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
-from qgis.PyQt.QtGui import QIcon, QStandardItem
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QIcon, QPainter, QPixmap, QStandardItem
 
 from qgis_hub_plugin.gui.constants import (
     CreatorRole,
@@ -20,13 +21,9 @@ class ResourceItem(QStandardItem):
     def __init__(self, params: dict):
         super().__init__()
 
-        # Attribute from the QGIS Hub
         self.resource_type = params.get("resource_type")
-
-        # Handle both old (resource_subtype string) and new (resource_subtypes array) formats
         self.resource_subtypes = normalize_resource_subtypes(params)
-
-        # Keep backward compatibility - resource_subtype as the first subtype or empty string
+        # First subtype kept for backward compatibility
         self.resource_subtype = (
             self.resource_subtypes[0] if self.resource_subtypes else ""
         )
@@ -41,24 +38,54 @@ class ResourceItem(QStandardItem):
         self.upload_date = datetime.fromisoformat(upload_date_string)
         self.download_count = params.get("download_count")
         self.description = params.get("description")
-        self.dependencies = params.get("dependencies")  # Add support for dependencies
+        self.dependencies = params.get("dependencies")
         self.file = params.get("file")
         self.thumbnail = params.get("thumbnail")
 
-        # Custom attribute
         self.setText(self.name[:50] + "..." if len(self.name) > 50 else self.name)
         self.setToolTip(f"{self.name} by {self.creator}")
         thumbnail_path = download_resource_thumbnail(self.thumbnail, self.uuid)
-        if thumbnail_path:
-            self.setIcon(QIcon(str(thumbnail_path)))
-        else:
-            self.setIcon(get_icon("QGIS_Hub_icon.svg"))
+        self.setIcon(self._make_uniform_icon(thumbnail_path))
 
         self.setData(self.resource_type, ResourceTypeRole)
         self.setData(self.name, NameRole)
         self.setData(self.creator, CreatorRole)
-        # Store subtypes as list in the role for filtering
         self.setData(self.resource_subtypes, ResourceSubtypeRole)
+
+    @staticmethod
+    def _make_uniform_icon(thumbnail_path, target_size=512):
+        """Return a square QIcon for *thumbnail_path*, centered on a transparent canvas.
+
+        Normalises varying thumbnail aspect ratios so every cell in the
+        QListView grid is the same size. Falls back to the default hub icon
+        when the image cannot be loaded.
+        """
+        if not thumbnail_path or thumbnail_path.name == "QGIS_Hub_icon.svg":
+            return get_icon("QGIS_Hub_icon.svg")
+
+        pixmap = QPixmap(str(thumbnail_path))
+        if pixmap.isNull():
+            return get_icon("QGIS_Hub_icon.svg")
+
+        # Scale to fit inside the target square, keeping aspect ratio
+        scaled = pixmap.scaled(
+            target_size,
+            target_size,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+
+        # Paint centered on a transparent square canvas
+        canvas = QPixmap(target_size, target_size)
+        canvas.fill(Qt.GlobalColor.transparent)
+
+        painter = QPainter(canvas)
+        x = (target_size - scaled.width()) // 2
+        y = (target_size - scaled.height()) // 2
+        painter.drawPixmap(x, y, scaled)
+        painter.end()
+
+        return QIcon(canvas)
 
 
 class AttributeSortingItem(QStandardItem):

--- a/qgis_hub_plugin/metadata.txt
+++ b/qgis_hub_plugin/metadata.txt
@@ -18,7 +18,8 @@ tracker=https://github.com/qgis/QGIS-Hub-Plugin/issues
 deprecated=False
 experimental=False
 qgisMinimumVersion=3.28
-qgisMaximumVersion=3.99
+qgisMaximumVersion=4.99
+supportsQt6=True
 
 # versioning
 version=0.5.0

--- a/qgis_hub_plugin/metadata.txt
+++ b/qgis_hub_plugin/metadata.txt
@@ -22,5 +22,5 @@ qgisMaximumVersion=4.99
 supportsQt6=True
 
 # versioning
-version=0.5.0
+version=1.0.0
 changelog=

--- a/qgis_hub_plugin/utilities/common.py
+++ b/qgis_hub_plugin/utilities/common.py
@@ -1,6 +1,7 @@
 import os
+import shutil
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from qgis.core import QgsApplication, QgsNetworkAccessManager, QgsNetworkReplyContent
 from qgis.PyQt.QtCore import QFile, QIODevice, QUrl
@@ -113,6 +114,46 @@ def download_file(
             raise e
         else:
             raise DownloadError(f"An unexpected error occurred: {str(e)}")
+
+
+def clear_cache() -> tuple[bool, int]:
+    """Delete the cached API response and all cached thumbnails.
+
+    Returns:
+        Tuple[bool, int]: (response_file_removed, number_of_thumbnails_removed).
+    """
+    response_removed = False
+    response_file = Path(QGIS_HUB_DIR, "response.json")
+    if response_file.exists():
+        response_file.unlink()
+        response_removed = True
+
+    thumbnails_removed = 0
+    thumbnail_dir = Path(QGIS_HUB_DIR, "thumbnails")
+    if thumbnail_dir.exists():
+        thumbnails_removed = sum(1 for _ in thumbnail_dir.iterdir() if _.is_file())
+        shutil.rmtree(thumbnail_dir)
+
+    return response_removed, thumbnails_removed
+
+
+def resource_thumbnail_cache_path(url: str, uuid: str) -> Optional[Path]:
+    """Return the expected on-disk cache path for a resource thumbnail, or
+    None if the resource has no downloadable thumbnail (missing URL or the
+    default QGIS Hub icon)."""
+    if not url or url.endswith("qgis-icon-32x32.png"):
+        return None
+    extension = "jpg"
+    try:
+        extension = url.split(".")[-1]
+    except IndexError:
+        pass
+    return Path(QGIS_HUB_DIR, "thumbnails", f"{uuid}.{extension}")
+
+
+def is_resource_thumbnail_cached(url: str, uuid: str) -> bool:
+    path = resource_thumbnail_cache_path(url, uuid)
+    return path is not None and path.exists()
 
 
 # If not able to download or not found, set the thumbnail to the default one

--- a/qgis_hub_plugin/utilities/common.py
+++ b/qgis_hub_plugin/utilities/common.py
@@ -14,7 +14,7 @@ from qgis_hub_plugin.utilities.exception import DownloadError
 QGIS_HUB_DIR = Path(QgsApplication.qgisSettingsDirPath(), "qgis_hub")
 
 
-def normalize_resource_subtypes(resource_data: dict) -> List[str]:
+def normalize_resource_subtypes(resource_data: dict) -> list[str]:
     """
     Normalize resource subtypes from API response to a list format.
 
@@ -85,9 +85,9 @@ def download_file(
     request.setTransferTimeout(timeout)
 
     def handle_finished(reply: QgsNetworkReplyContent):
-        if reply.error() == QNetworkReply.NoError:
+        if reply.error() == QNetworkReply.NetworkError.NoError:
             file = QFile(str(destination))
-            if file.open(QIODevice.WriteOnly):
+            if file.open(QIODevice.OpenModeFlag.WriteOnly):
                 file.write(reply.readAll())
                 file.close()
                 return destination
@@ -95,7 +95,7 @@ def download_file(
                 raise DownloadError(
                     f"Failed to open file for writing: {file.errorString()}"
                 )
-        elif reply.error() == QNetworkReply.ContentNotFoundError:
+        elif reply.error() == QNetworkReply.NetworkError.ContentNotFoundError:
             raise DownloadError(f"File not found (404 error): {url}")
         else:
             raise DownloadError(f"Download failed: {reply.errorString()}")

--- a/qgis_hub_plugin/utilities/common.py
+++ b/qgis_hub_plugin/utilities/common.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple
 
 from qgis.core import QgsApplication, QgsNetworkAccessManager, QgsNetworkReplyContent
 from qgis.PyQt.QtCore import QFile, QIODevice, QUrl
-from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtGui import QIcon, QImageReader
 from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
 
 from qgis_hub_plugin.__about__ import DIR_PLUGIN_ROOT
@@ -13,6 +13,22 @@ from qgis_hub_plugin.toolbelt import PlgLogger
 from qgis_hub_plugin.utilities.exception import DownloadError
 
 QGIS_HUB_DIR = Path(QgsApplication.qgisSettingsDirPath(), "qgis_hub")
+
+# Image formats Qt can decode in this QGIS install (e.g. {"jpg", "png", "webp"}).
+# Qt5 ships the webp plugin; Qt6 may not. Computed once at import time so we
+# don't probe every thumbnail file on disk.
+_QT_SUPPORTED_IMAGE_FORMATS = {
+    bytes(fmt).decode("ascii").lower() for fmt in QImageReader.supportedImageFormats()
+}
+
+
+def _qt_can_decode(extension: str) -> bool:
+    ext = extension.lower().lstrip(".")
+    if ext == "jpg":
+        ext = "jpeg"
+    return ext in _QT_SUPPORTED_IMAGE_FORMATS or (
+        ext == "jpeg" and "jpg" in _QT_SUPPORTED_IMAGE_FORMATS
+    )
 
 
 def normalize_resource_subtypes(resource_data: dict) -> list[str]:
@@ -179,7 +195,41 @@ def download_resource_thumbnail(url: str, uuid: str) -> Path:
         thumbnail_dir.mkdir(parents=True, exist_ok=True)
 
     status = download_file(url, thumbnail_path, False)
-    if status and thumbnail_path.exists():
-        return thumbnail_path
-    else:
+    if not (status and thumbnail_path.exists()):
         return Path(get_icon_path("QGIS_Hub_icon.svg"))
+
+    # Qt5 ships the webp image-format plugin, so this branch was a no-op
+    # in QGIS 3. Qt6 in QGIS 4 may lack it: when Qt cannot decode this
+    # extension, fall back to a one-shot Pillow conversion to PNG. The
+    # PNG sibling is reused on subsequent calls so we never re-decode.
+    if _qt_can_decode(extension):
+        return thumbnail_path
+
+    png_path = thumbnail_path.with_suffix(".png")
+    if png_path.exists() and png_path.stat().st_size > 0:
+        return png_path
+
+    converted = _convert_thumbnail_to_png(thumbnail_path, png_path)
+    if converted is not None:
+        return converted
+    return Path(get_icon_path("QGIS_Hub_icon.svg"))
+
+
+def _convert_thumbnail_to_png(source: Path, target: Path) -> Optional[Path]:
+    try:
+        from PIL import Image
+    except ImportError:
+        PlgLogger.log(
+            f"Cannot decode {source.name} and Pillow is unavailable for conversion."
+        )
+        return None
+    try:
+        with Image.open(source) as img:
+            # Cap to a sensible thumbnail size so conversion stays fast even
+            # when the source is a full-resolution screenshot/map preview.
+            img.thumbnail((512, 512))
+            img.convert("RGBA").save(target, format="PNG", optimize=True)
+        return target
+    except Exception as exc:  # noqa: BLE001
+        PlgLogger.log(f"Failed to convert thumbnail {source.name}: {exc}")
+        return None

--- a/qgis_hub_plugin/utilities/common.py
+++ b/qgis_hub_plugin/utilities/common.py
@@ -14,15 +14,25 @@ from qgis_hub_plugin.utilities.exception import DownloadError
 
 QGIS_HUB_DIR = Path(QgsApplication.qgisSettingsDirPath(), "qgis_hub")
 
-# Image formats Qt can decode in this QGIS install (e.g. {"jpg", "png", "webp"}).
-# Qt5 ships the webp plugin; Qt6 may not. Computed once at import time so we
-# don't probe every thumbnail file on disk.
+# Image formats Qt can decode in this build (e.g. {"jpg", "png", "webp"}).
+# Qt5 ships the webp plugin; Qt6 in QGIS 4 does NOT include it.
+# Computed once at import time to avoid probing on every thumbnail.
 _QT_SUPPORTED_IMAGE_FORMATS = {
     bytes(fmt).decode("ascii").lower() for fmt in QImageReader.supportedImageFormats()
 }
 
+# Pillow is an optional dependency used to convert image formats that Qt
+# cannot decode (e.g. webp on Qt6). Detected once at import time.
+try:
+    from PIL import Image as _PILImage
+
+    HAS_PILLOW = True
+except ImportError:
+    HAS_PILLOW = False
+
 
 def _qt_can_decode(extension: str) -> bool:
+    """Check whether Qt can natively decode the given image extension."""
     ext = extension.lower().lstrip(".")
     if ext == "jpg":
         ext = "jpeg"
@@ -53,16 +63,12 @@ def normalize_resource_subtypes(resource_data: dict) -> list[str]:
         >>> normalize_resource_subtypes({"resource_subtype": ""})
         []
     """
-    # Handle new API format (resource_subtypes array)
     if "resource_subtypes" in resource_data:
         subtypes = resource_data.get("resource_subtypes", [])
-        # Ensure it's a list
         if isinstance(subtypes, list):
             return subtypes
-        # Handle edge case where it might be a single value
         return [subtypes] if subtypes else []
 
-    # Handle old API format (resource_subtype string)
     subtype = resource_data.get("resource_subtype", "")
     return [subtype] if subtype else []
 
@@ -172,18 +178,14 @@ def is_resource_thumbnail_cached(url: str, uuid: str) -> bool:
     return path is not None and path.exists()
 
 
-# If not able to download or not found, set the thumbnail to the default one
 def download_resource_thumbnail(url: str, uuid: str) -> Path:
     if not url:
         PlgLogger.log(f"UUID: {uuid} has URL == None: {url}")
         return Path(get_icon_path("QGIS_Hub_icon.svg"))
-    # If the URL is the default QGIS Hub icon, return the default icon.
-    # Because it is not a thumbnail and it is too small
     if url.endswith("qgis-icon-32x32.png"):
         return Path(get_icon_path("QGIS_Hub_icon.svg"))
 
-    # Assume it as jpg
-    extension = ".jpg"
+    extension = "jpg"
     try:
         extension = url.split(".")[-1]
     except IndexError as e:
@@ -198,12 +200,19 @@ def download_resource_thumbnail(url: str, uuid: str) -> Path:
     if not (status and thumbnail_path.exists()):
         return Path(get_icon_path("QGIS_Hub_icon.svg"))
 
-    # Qt5 ships the webp image-format plugin, so this branch was a no-op
-    # in QGIS 3. Qt6 in QGIS 4 may lack it: when Qt cannot decode this
-    # extension, fall back to a one-shot Pillow conversion to PNG. The
-    # PNG sibling is reused on subsequent calls so we never re-decode.
+    # Qt5 ships the webp image-format plugin so thumbnails rendered directly.
+    # Qt6 in QGIS 4 does NOT include webp support (confirmed by testing).
+    # When Qt cannot decode the format, fall back to a one-shot Pillow
+    # conversion to PNG. The PNG sibling is reused on subsequent calls.
     if _qt_can_decode(extension):
         return thumbnail_path
+
+    if not HAS_PILLOW:
+        PlgLogger.log(
+            f"Qt cannot decode .{extension} and Pillow is not installed. "
+            "Install Pillow (`pip install Pillow`) to display webp thumbnails."
+        )
+        return Path(get_icon_path("QGIS_Hub_icon.svg"))
 
     png_path = thumbnail_path.with_suffix(".png")
     if png_path.exists() and png_path.stat().st_size > 0:
@@ -216,17 +225,12 @@ def download_resource_thumbnail(url: str, uuid: str) -> Path:
 
 
 def _convert_thumbnail_to_png(source: Path, target: Path) -> Optional[Path]:
+    """Convert a thumbnail to PNG using Pillow.
+
+    Only called when HAS_PILLOW is True, so the import is guaranteed to succeed.
+    """
     try:
-        from PIL import Image
-    except ImportError:
-        PlgLogger.log(
-            f"Cannot decode {source.name} and Pillow is unavailable for conversion."
-        )
-        return None
-    try:
-        with Image.open(source) as img:
-            # Cap to a sensible thumbnail size so conversion stays fast even
-            # when the source is a full-resolution screenshot/map preview.
+        with _PILImage.open(source) as img:
             img.thumbnail((512, 512))
             img.convert("RGBA").save(target, format="PNG", optimize=True)
         return target

--- a/qgis_hub_plugin/utilities/qgis_util.py
+++ b/qgis_hub_plugin/utilities/qgis_util.py
@@ -4,7 +4,7 @@ from qgis.PyQt.QtWidgets import QApplication
 
 def show_busy_cursor(func):
     def wrapper(*args, **kwargs):
-        QApplication.setOverrideCursor(Qt.WaitCursor)
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         QCoreApplication.processEvents()
 
         try:

--- a/tests/qgis/test_filter_proxy.py
+++ b/tests/qgis/test_filter_proxy.py
@@ -17,7 +17,7 @@ Usage from the repo root folder:
 
 import unittest
 
-from qgis.PyQt.QtCore import QRegExp, Qt
+from qgis.PyQt.QtCore import QRegularExpression, Qt
 from qgis.PyQt.QtGui import QStandardItem, QStandardItemModel
 from qgis.testing import start_app
 
@@ -129,7 +129,7 @@ class TestFilterProxyModel(unittest.TestCase):
         self.proxy.setRolesToFilter([NameRole])
 
         # Search for "Model"
-        self.proxy.setFilterRegExp(QRegExp(".*Model.*"))
+        self.proxy.setFilterRegularExpression(QRegularExpression(".*Model.*"))
 
         # Should show 2 models
         self.assertEqual(self.proxy.rowCount(), 2)
@@ -142,7 +142,7 @@ class TestFilterProxyModel(unittest.TestCase):
         self.proxy.setRolesToFilter([CreatorRole])
 
         # Search for "Creator A"
-        self.proxy.setFilterRegExp(QRegExp("Creator A"))
+        self.proxy.setFilterRegularExpression(QRegularExpression("Creator A"))
 
         # Should show 2 items by Creator A
         self.assertEqual(self.proxy.rowCount(), 2)
@@ -154,7 +154,7 @@ class TestFilterProxyModel(unittest.TestCase):
         self.proxy.setRolesToFilter([NameRole])
 
         # Search for "1"
-        self.proxy.setFilterRegExp(QRegExp(".*1"))
+        self.proxy.setFilterRegularExpression(QRegularExpression(".*1"))
 
         # Should show only "Processing Model 1"
         self.assertEqual(self.proxy.rowCount(), 1)
@@ -169,7 +169,7 @@ class TestFilterProxyModel(unittest.TestCase):
         self.proxy.setRolesToFilter([NameRole])
 
         # Search for something that doesn't exist
-        self.proxy.setFilterRegExp(QRegExp("NonExistentResource"))
+        self.proxy.setFilterRegularExpression(QRegularExpression("NonExistentResource"))
 
         # Should show 0 items
         self.assertEqual(self.proxy.rowCount(), 0)
@@ -218,8 +218,10 @@ class TestFilterProxyModel(unittest.TestCase):
         self.proxy.setRolesToFilter([NameRole])
 
         # Search with different case
-        regex = QRegExp(".*python.*", Qt.CaseInsensitive)
-        self.proxy.setFilterRegExp(regex)
+        regex = QRegularExpression(
+            ".*python.*", QRegularExpression.PatternOption.CaseInsensitiveOption
+        )
+        self.proxy.setFilterRegularExpression(regex)
 
         # Should match "Python Script 1"
         self.assertEqual(self.proxy.rowCount(), 1)
@@ -233,7 +235,7 @@ class TestFilterProxyModel(unittest.TestCase):
         self.proxy.setRolesToFilter([NameRole, CreatorRole])
 
         # Search for "Creator A" - should match in creator role
-        self.proxy.setFilterRegExp(QRegExp("Creator A"))
+        self.proxy.setFilterRegularExpression(QRegularExpression("Creator A"))
 
         # Should show 2 items by Creator A
         self.assertEqual(self.proxy.rowCount(), 2)

--- a/tests/qgis/test_filter_proxy.py
+++ b/tests/qgis/test_filter_proxy.py
@@ -202,7 +202,7 @@ class TestFilterProxyModel(unittest.TestCase):
         self.proxy.setRolesToFilter([NameRole])
 
         # Sort by column 0 (which has SortingRole data)
-        self.proxy.sort(0, 1)  # 1 = Descending
+        self.proxy.sort(0, Qt.SortOrder.DescendingOrder)
 
         # Verify order by download count (50, 40, 30, 20, 15, 10)
         expected_counts = [50, 40, 30, 20, 15, 10]

--- a/tests/qgis/test_resource_item.py
+++ b/tests/qgis/test_resource_item.py
@@ -21,12 +21,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Try to import QIcon from QGIS for use in mocks
+# Try to import QIcon and ResourceItem from QGIS for use in mocks
 try:
     from qgis.PyQt.QtGui import QIcon
+
+    from qgis_hub_plugin.gui.resource_item import ResourceItem
 except ImportError:
-    # Create a mock QIcon class for when QGIS is not available
+    # Create mock classes for when QGIS is not available
     QIcon = MagicMock
+    ResourceItem = MagicMock
 
 
 class TestResourceItem(unittest.TestCase):
@@ -125,26 +128,24 @@ class TestResourceItem(unittest.TestCase):
         self.assertEqual(item.name, long_name)
 
     @patch("qgis_hub_plugin.gui.resource_item.download_resource_thumbnail")
-    @patch("qgis_hub_plugin.gui.resource_item.QIcon")
-    def test_thumbnail_icon_loading(self, mock_qicon, mock_download_thumb):
-        """Test that thumbnail is loaded when available."""
+    @patch.object(ResourceItem, "_make_uniform_icon", return_value=QIcon())
+    def test_thumbnail_icon_loading(self, mock_make_icon, mock_download_thumb):
+        """Test that thumbnail is downloaded and passed to the icon builder."""
         from pathlib import Path
 
         from qgis_hub_plugin.gui.resource_item import ResourceItem
 
-        # Mock successful thumbnail download
         mock_thumb_path = Path("/tmp/thumb.jpg")
         mock_download_thumb.return_value = mock_thumb_path
-        # Mock QIcon to return a real QIcon object (Qt requires actual QIcon, not MagicMock)
-        mock_qicon.return_value = QIcon()
 
         item = ResourceItem(self.sample_resource)
 
-        # Verify thumbnail was used for icon
+        # Verify thumbnail was downloaded with correct arguments
         mock_download_thumb.assert_called_once_with(
             "https://example.com/thumb.jpg", "test-uuid-123"
         )
-        mock_qicon.assert_called_with(str(mock_thumb_path))
+        # Verify the downloaded path was passed to the icon builder
+        mock_make_icon.assert_called_once_with(mock_thumb_path)
 
     @patch("qgis_hub_plugin.gui.resource_item.download_resource_thumbnail")
     @patch("qgis_hub_plugin.gui.resource_item.get_icon")

--- a/tests/qgis/test_resource_item.py
+++ b/tests/qgis/test_resource_item.py
@@ -24,8 +24,12 @@ import pytest
 # Try to import QIcon and ResourceItem from QGIS for use in mocks
 try:
     from qgis.PyQt.QtGui import QIcon
+    from qgis.testing import start_app
 
     from qgis_hub_plugin.gui.resource_item import ResourceItem
+
+    # Ensure a QApplication exists for tests that build real QPixmap/QIcon
+    start_app()
 except ImportError:
     # Create mock classes for when QGIS is not available
     QIcon = MagicMock
@@ -202,6 +206,67 @@ class TestResourceItem(unittest.TestCase):
         # Verify whitespace is stripped
         self.assertEqual(item.name, "Test Resource")
         self.assertEqual(item.creator, "Test Creator")
+
+
+class TestMakeUniformIcon(unittest.TestCase):
+    """Test ResourceItem._make_uniform_icon."""
+
+    def test_fallback_when_path_is_none(self):
+        """None path returns the default hub icon."""
+        from qgis_hub_plugin.gui.resource_item import ResourceItem
+
+        icon = ResourceItem._make_uniform_icon(None)
+        self.assertIsInstance(icon, QIcon)
+        self.assertFalse(icon.isNull())
+
+    def test_fallback_when_path_is_default_hub_icon(self):
+        """A path pointing at the bundled QGIS_Hub_icon.svg short-circuits."""
+        from pathlib import Path
+
+        from qgis_hub_plugin.gui.resource_item import ResourceItem
+
+        icon = ResourceItem._make_uniform_icon(Path("/x/QGIS_Hub_icon.svg"))
+        self.assertIsInstance(icon, QIcon)
+        self.assertFalse(icon.isNull())
+
+    def test_fallback_when_pixmap_is_null(self):
+        """Unreadable thumbnail file falls back to default icon."""
+        import tempfile
+        from pathlib import Path
+
+        from qgis_hub_plugin.gui.resource_item import ResourceItem
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bogus = Path(tmpdir) / "broken.jpg"
+            bogus.write_bytes(b"not a real image")
+
+            icon = ResourceItem._make_uniform_icon(bogus)
+            self.assertIsInstance(icon, QIcon)
+            self.assertFalse(icon.isNull())
+
+    def test_returns_square_canvas_for_valid_image(self):
+        """Valid thumbnail is centered on a square canvas of target_size."""
+        import tempfile
+        from pathlib import Path
+
+        from qgis.PyQt.QtGui import QImage
+
+        from qgis_hub_plugin.gui.resource_item import ResourceItem
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a non-square test image so we can verify the canvas is square
+            src = Path(tmpdir) / "thumb.png"
+            img = QImage(80, 40, QImage.Format.Format_ARGB32)
+            img.fill(0xFF0000FF)
+            self.assertTrue(img.save(str(src), "PNG"))
+
+            icon = ResourceItem._make_uniform_icon(src, target_size=128)
+            self.assertIsInstance(icon, QIcon)
+            self.assertFalse(icon.isNull())
+
+            pixmap = icon.pixmap(128, 128)
+            self.assertEqual(pixmap.width(), 128)
+            self.assertEqual(pixmap.height(), 128)
 
 
 class TestAttributeSortingItem(unittest.TestCase):

--- a/tests/qgis/test_utilities.py
+++ b/tests/qgis/test_utilities.py
@@ -332,6 +332,188 @@ def test_thumbnail_extension_detection(url, uuid, expected_extension):
                 assert str(destination_path).endswith(expected_extension)
 
 
+class TestCachePathHelpers(unittest.TestCase):
+    """Test resource_thumbnail_cache_path and is_resource_thumbnail_cached."""
+
+    def test_cache_path_none_for_empty_url(self):
+        from qgis_hub_plugin.utilities.common import resource_thumbnail_cache_path
+
+        self.assertIsNone(resource_thumbnail_cache_path("", "uuid-1"))
+
+    def test_cache_path_none_for_default_icon_url(self):
+        from qgis_hub_plugin.utilities.common import resource_thumbnail_cache_path
+
+        url = "https://example.com/qgis-icon-32x32.png"
+        self.assertIsNone(resource_thumbnail_cache_path(url, "uuid-1"))
+
+    def test_cache_path_uses_url_extension(self):
+        from qgis_hub_plugin.utilities.common import resource_thumbnail_cache_path
+
+        path = resource_thumbnail_cache_path(
+            "https://example.com/thumb.webp", "uuid-abc"
+        )
+        self.assertIsNotNone(path)
+        self.assertTrue(str(path).endswith("uuid-abc.webp"))
+
+    def test_is_cached_false_when_missing(self, tmp_path=None):
+        from qgis_hub_plugin.utilities.common import is_resource_thumbnail_cached
+
+        self.assertFalse(
+            is_resource_thumbnail_cached(
+                "https://example.com/thumb.jpg", "uuid-not-on-disk"
+            )
+        )
+
+    def test_is_cached_false_for_default_icon(self):
+        from qgis_hub_plugin.utilities.common import is_resource_thumbnail_cached
+
+        self.assertFalse(
+            is_resource_thumbnail_cached(
+                "https://example.com/qgis-icon-32x32.png", "uuid-x"
+            )
+        )
+
+    def test_is_cached_true_when_file_exists(self):
+        from qgis_hub_plugin.utilities import common
+
+        with patch.object(common, "QGIS_HUB_DIR", Path("/nonexistent-base")):
+            with patch("pathlib.Path.exists", return_value=True):
+                self.assertTrue(
+                    common.is_resource_thumbnail_cached(
+                        "https://example.com/thumb.jpg", "uuid-cached"
+                    )
+                )
+
+
+class TestQtCanDecode(unittest.TestCase):
+    """Test _qt_can_decode capability probe."""
+
+    def test_returns_true_for_supported_format(self):
+        from qgis_hub_plugin.utilities import common
+
+        with patch.object(common, "_QT_SUPPORTED_IMAGE_FORMATS", {"png", "jpeg"}):
+            self.assertTrue(common._qt_can_decode("png"))
+            self.assertTrue(common._qt_can_decode("PNG"))
+            self.assertTrue(common._qt_can_decode(".png"))
+
+    def test_jpg_aliases_to_jpeg(self):
+        from qgis_hub_plugin.utilities import common
+
+        with patch.object(common, "_QT_SUPPORTED_IMAGE_FORMATS", {"jpeg"}):
+            self.assertTrue(common._qt_can_decode("jpg"))
+
+        with patch.object(common, "_QT_SUPPORTED_IMAGE_FORMATS", {"jpg"}):
+            self.assertTrue(common._qt_can_decode("jpeg"))
+
+    def test_returns_false_for_unsupported_format(self):
+        from qgis_hub_plugin.utilities import common
+
+        with patch.object(common, "_QT_SUPPORTED_IMAGE_FORMATS", {"png", "jpeg"}):
+            self.assertFalse(common._qt_can_decode("webp"))
+
+
+class TestClearCache(unittest.TestCase):
+    """Test clear_cache helper."""
+
+    def test_clear_cache_removes_response_and_thumbnails(self, tmp_path=None):
+        import tempfile
+
+        from qgis_hub_plugin.utilities import common
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            (base / "response.json").write_text("{}")
+            thumb_dir = base / "thumbnails"
+            thumb_dir.mkdir()
+            (thumb_dir / "a.jpg").write_bytes(b"x")
+            (thumb_dir / "b.png").write_bytes(b"y")
+
+            with patch.object(common, "QGIS_HUB_DIR", base):
+                response_removed, n = common.clear_cache()
+
+            self.assertTrue(response_removed)
+            self.assertEqual(n, 2)
+            self.assertFalse((base / "response.json").exists())
+            self.assertFalse(thumb_dir.exists())
+
+    def test_clear_cache_when_nothing_exists(self):
+        import tempfile
+
+        from qgis_hub_plugin.utilities import common
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(common, "QGIS_HUB_DIR", Path(tmpdir)):
+                response_removed, n = common.clear_cache()
+
+            self.assertFalse(response_removed)
+            self.assertEqual(n, 0)
+
+    def test_clear_cache_response_only(self):
+        import tempfile
+
+        from qgis_hub_plugin.utilities import common
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            (base / "response.json").write_text("{}")
+
+            with patch.object(common, "QGIS_HUB_DIR", base):
+                response_removed, n = common.clear_cache()
+
+            self.assertTrue(response_removed)
+            self.assertEqual(n, 0)
+
+
+class TestConvertThumbnailToPng(unittest.TestCase):
+    """Test _convert_thumbnail_to_png Pillow fallback."""
+
+    def test_convert_success(self):
+        import tempfile
+
+        from qgis_hub_plugin.utilities import common
+
+        if not common.HAS_PILLOW:
+            self.skipTest("Pillow not installed")
+
+        from PIL import Image
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "thumb.webp"
+            target = Path(tmpdir) / "thumb.png"
+
+            img = Image.new("RGB", (64, 32), color="red")
+            try:
+                img.save(source, format="WEBP")
+            except (KeyError, OSError):
+                # Pillow build without WEBP encoder — fall back to PNG source
+                source = Path(tmpdir) / "thumb.bmp"
+                img.save(source, format="BMP")
+
+            result = common._convert_thumbnail_to_png(source, target)
+
+            self.assertEqual(result, target)
+            self.assertTrue(target.exists())
+            self.assertGreater(target.stat().st_size, 0)
+
+    def test_convert_returns_none_on_failure(self):
+        import tempfile
+
+        from qgis_hub_plugin.utilities import common
+
+        if not common.HAS_PILLOW:
+            self.skipTest("Pillow not installed")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "broken.webp"
+            source.write_bytes(b"not an image")
+            target = Path(tmpdir) / "broken.png"
+
+            result = common._convert_thumbnail_to_png(source, target)
+
+            self.assertIsNone(result)
+            self.assertFalse(target.exists())
+
+
 # ############################################################################
 # ####### Stand-alone run ########
 # ################################

--- a/tests/qgis/test_utilities.py
+++ b/tests/qgis/test_utilities.py
@@ -318,19 +318,22 @@ def test_thumbnail_extension_detection(url, uuid, expected_extension):
     """
     from qgis_hub_plugin.utilities.common import download_resource_thumbnail
 
-    with patch("qgis_hub_plugin.utilities.common.download_file") as mock_download:
-        with patch("qgis_hub_plugin.utilities.common.QgsApplication") as mock_qgs:
-            with patch("pathlib.Path.exists") as mock_exists:
-                mock_qgs.qgisSettingsDirPath.return_value = "/tmp/qgis"
-                mock_download.return_value = True
-                mock_exists.return_value = True
+    # Force Qt-can-decode True so the webp case doesn't fall into the Pillow
+    # conversion branch (which would need a real source file on disk).
+    with patch("qgis_hub_plugin.utilities.common._qt_can_decode", return_value=True):
+        with patch("qgis_hub_plugin.utilities.common.download_file") as mock_download:
+            with patch("qgis_hub_plugin.utilities.common.QgsApplication") as mock_qgs:
+                with patch("pathlib.Path.exists") as mock_exists:
+                    mock_qgs.qgisSettingsDirPath.return_value = "/tmp/qgis"
+                    mock_download.return_value = True
+                    mock_exists.return_value = True
 
-                download_resource_thumbnail(url, uuid)
+                    download_resource_thumbnail(url, uuid)
 
-                # Check that download was called with correct extension
-                call_args = mock_download.call_args
-                destination_path = call_args[0][1]
-                assert str(destination_path).endswith(expected_extension)
+                    # Check that download was called with correct extension
+                    call_args = mock_download.call_args
+                    destination_path = call_args[0][1]
+                    assert str(destination_path).endswith(expected_extension)
 
 
 class TestCachePathHelpers(unittest.TestCase):

--- a/tests/qgis/test_utilities.py
+++ b/tests/qgis/test_utilities.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from qgis.PyQt.QtNetwork import QNetworkReply
 
 
 class TestDownloadUtilities(unittest.TestCase):
@@ -34,7 +35,7 @@ class TestDownloadUtilities(unittest.TestCase):
 
         # Setup mock network reply
         mock_reply = MagicMock()
-        mock_reply.error.return_value = 0  # QNetworkReply.NoError
+        mock_reply.error.return_value = QNetworkReply.NetworkError.NoError
         mock_reply.isFinished.return_value = True
         mock_reply.readAll.return_value = b"file content data"
 
@@ -71,7 +72,7 @@ class TestDownloadUtilities(unittest.TestCase):
 
         # Setup mock network reply with 404 error
         mock_reply = MagicMock()
-        mock_reply.error.return_value = 203  # QNetworkReply.ContentNotFoundError
+        mock_reply.error.return_value = QNetworkReply.NetworkError.ContentNotFoundError
         mock_reply.isFinished.return_value = True
         mock_reply.errorString.return_value = "Not Found"
 
@@ -95,7 +96,7 @@ class TestDownloadUtilities(unittest.TestCase):
 
         # Setup mock network reply with error
         mock_reply = MagicMock()
-        mock_reply.error.return_value = 99  # Some network error
+        mock_reply.error.return_value = QNetworkReply.NetworkError.TimeoutError
         mock_reply.isFinished.return_value = True
         mock_reply.errorString.return_value = "Network timeout"
 
@@ -121,7 +122,7 @@ class TestDownloadUtilities(unittest.TestCase):
 
         # Setup successful network reply
         mock_reply = MagicMock()
-        mock_reply.error.return_value = 0
+        mock_reply.error.return_value = QNetworkReply.NetworkError.NoError
         mock_reply.isFinished.return_value = True
         mock_reply.readAll.return_value = b"data"
 


### PR DESCRIPTION
## Summary
Draft built on top of #145 (Valentin Buira) to validate QGIS 4 / Qt6 support in CI.

- Adds test coverage for new Qt6 webp fallback, cache helpers, `clear_cache`, and `ResourceItem._make_uniform_icon`
- Fixes test mocks that silently broke under PyQt6 (scoped `QNetworkReply.NetworkError.*` and `Qt.SortOrder.DescendingOrder`)
- Adds **Qt6/QGIS 4 to the integration-test matrix** (parallel to the existing 3.34 LTS job) — the actual point of this draft

Once CI is green on both Qt5 and Qt6, the test commits here can be folded back into #145.

## Test plan
- [ ] CI integration job passes on `qgis/qgis:release-3_34` (Qt5)
- [ ] CI integration job passes on `qgis/qgis:4.0` (Qt6) — this is the new check
- [ ] Local: `pytest tests/ -v` green on QGIS 4.0.2 / PyQt6 (verified: 113 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)