### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,54 @@ Unreleased
 
 -->
 
+## 0.6.0 - 2026-05-15
+
+### Added
+
+- Added support for QGIS 4 / Qt6 alongside existing QGIS 3 / Qt5 support
+  (`supportsQt6=True`, `qgisMaximumVersion=4.99`)
+- Added Pillow-based webp thumbnail fallback for Qt6 (Qt6 in QGIS 4 does
+  not ship the webp image-format plugin); Pillow is an optional
+  dependency
+- Added "Clear cache" button in the plugin settings to wipe the cached
+  resource list and downloaded thumbnails
+- Added thumbnail download progress bar in the QGIS message bar during
+  initial resource browser population
+- Added uniform square-canvas icon rendering so list-view cells are the
+  same size regardless of thumbnail aspect ratio
+- Added clearer error message when adding a PyQt5-only processing script
+  on Qt6 (instead of an opaque traceback)
+- Added Qt6 / QGIS 4 integration test job to CI (`qgis/qgis:4.0`)
+  alongside the existing Qt5 LTR job
+- Added tests for the Qt6 webp fallback, cache helpers, `clear_cache`,
+  and `ResourceItem._make_uniform_icon`
+- Added Qt6 / QGIS 4 migration documentation under the contribution
+  guide
+
+### Changed
+
+- Migrated all Qt enum usage to the fully-scoped form
+  (`Qt.ItemDataRole.UserRole`, `QSizePolicy.Policy.Minimum`,
+  `QNetworkReply.NetworkError.NoError`, etc.) so the codebase works on
+  both PyQt5 and PyQt6
+- Replaced `QRegExp` with `QRegularExpression` in filter proxy and
+  resource browser (Qt6 dropped `QRegExp`)
+- Bumped pre-commit `black` to 25.1.0 and `pyupgrade` to 3.21.2 for
+  Python 3.14 compatibility
+
+### Fixed
+
+- Fixed `tr()` + f-string usage in new error branches; translations are
+  now extractable by `pylupdate` via `tr("...").format(...)`
+- Fixed `clear_cache` to count files recursively (`rglob`) so nested
+  thumbnail files are reflected in the returned count
+- Fixed `is_resource_thumbnail_cached` to accept the converted `.png`
+  sibling as a cache hit when Qt cannot decode the original format
+- Fixed re-entrancy risk in `populate_resources` by throttling
+  `QgsApplication.processEvents()` to every 10 items plus a final flush
+- Fixed list-view thumbnail-size slider on Qt6 by also updating
+  `setGridSize` in `update_icon_size`
+
 ## 0.5.0 - 2025-12-25
 
 ### Added

--- a/docs/development/qt6-migration.md
+++ b/docs/development/qt6-migration.md
@@ -1,7 +1,7 @@
 # Qt6 / QGIS 4 migration notes
 
 Reference notes for the QGIS 3 / Qt5 → QGIS 4 / Qt6 migration done in
-`v1.0.0`. Future maintainers hitting odd Qt6 behaviour: start here.
+`v0.6.0`. Future maintainers hitting odd Qt6 behaviour: start here.
 
 The plugin supports **both** Qt5 (QGIS 3.28+) and Qt6 (QGIS 4.x) from a
 single codebase. CI runs the integration suite on both `qgis/qgis:release-3_34`
@@ -137,13 +137,12 @@ still saved to disk so the user can edit and re-add it.
 
 ## 8. Things still not working on Qt6
 
-Tracked but not fixed in `v1.0.0`:
+Tracked but not fixed in `v0.6.0`:
 
-- The thumbnail-size slider in the icon view has no effect under Qt6
-  (does not crash; just silently does nothing).
 - PyQt5-only processing scripts cannot be loaded until the upstream
-  script is updated to import from `qgis.PyQt`.
+  script is updated to import from `qgis.PyQt`. The error is surfaced
+  cleanly (see section 7); a real fix would need upstream cooperation
+  from script authors on QGIS Hub.
 
-If you pick either up, the relevant entry points are
-`update_icon_size` and `add_processing_script_to_qgis` in
+The relevant entry point is `add_processing_script_to_qgis` in
 `gui/resource_browser.py`.

--- a/qgis_hub_plugin/metadata.txt
+++ b/qgis_hub_plugin/metadata.txt
@@ -22,5 +22,5 @@ qgisMaximumVersion=4.99
 supportsQt6=True
 
 # versioning
-version=1.0.0
+version=0.6.0
 changelog=


### PR DESCRIPTION
## Summary
- Roll back the metadata version from 1.0.0 (set in #145) to 0.6.0 to better reflect maturity given the known limitation around PyQt5-only processing scripts on Qt6
- Add a 0.6.0 entry to CHANGELOG.md summarising the Qt6 / QGIS 4 work from #145
- Minor fixup in the Qt6 migration doc: the thumbnail-size slider works under Qt6 (b48924f set the grid size), so it no longer belongs in the "not working" list

## Test plan
- [ ] CI green
- [ ] \`qgis_hub_plugin/__about__.py\` reads version from metadata at runtime — confirmed no other hardcoded version strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)