### PR TITLE
Fix insecure temp file usage in add_style_to_qgis

### DIFF
--- a/qgis_hub_plugin/gui/resource_browser.py
+++ b/qgis_hub_plugin/gui/resource_browser.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import tempfile
 import zipfile
 from functools import partial
@@ -752,10 +751,8 @@ class ResourceBrowserDialog(QDialog, UI_CLASS):
     @show_busy_cursor
     def add_style_to_qgis(self):
         resource = self.selected_resource
-        tempdir = Path(
-            "/tmp" if platform.system() == "Darwin" else tempfile.gettempdir()
-        )
-        tempfile_path = Path(tempdir, resource.file.split("/")[-1])
+        tempdir = Path(tempfile.mkdtemp(prefix="qgis_hub_"))
+        tempfile_path = tempdir / resource.file.split("/")[-1]
         download_file(resource.file, tempfile_path, True)
 
         # Add to QGIS style library


### PR DESCRIPTION
## Summary
- Replace hardcoded `/tmp` (Darwin) / shared `tempfile.gettempdir()` with a private `tempfile.mkdtemp(prefix="qgis_hub_")` directory in `add_style_to_qgis` to avoid predictable temp paths and symlink/race risks (mode 0700, unique per call).
- Drop the now-unused `platform` import.

## Test plan
- [x] `pytest tests/ -v` — 116 passed
- [x] `pre-commit` hooks pass (black, isort, pyupgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)