### PR TITLE
Bulk-bump CI actions and dev/docs deps

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Get source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -46,7 +46,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache Sphinx cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: docs/_build/cache
           key: ${{ runner.os }}-sphinx-${{ hashFiles('docs/**/*') }}
@@ -62,7 +62,7 @@ jobs:
         run: sphinx-build -b html -j auto -d docs/_build/cache -q docs docs/_build/html
 
       - name: Save build doc as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: documentation
           path: docs/_build/html/*
@@ -70,11 +70,11 @@ jobs:
           retention-days: 30
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
         if: ${{ github.event_name == 'push' && ( startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' ) }}
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         if: ${{ github.event_name == 'push' && ( startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' ) }}
         with:
           # Upload entire repository

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Get source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Get source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Get source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Get source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Print QGIS version
         run: |

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -5,7 +5,7 @@ black
 
 flake8-builtins>=1.5,<2.3
 flake8-isort>=4.1,<6.2
-flake8-qgis>=1,<1.1
+flake8-qgis>=1,<1.2
 
 isort>=5.8,<5.14
-pre-commit>=3,<4
+pre-commit>=3,<5

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -4,4 +4,4 @@
 myst-parser[linkify]>=1,<3
 sphinx-autobuild==2021.*
 sphinx-copybutton>=0.2,<1
-sphinx-rtd-theme>=1,<3
+sphinx-rtd-theme>=1,<4


### PR DESCRIPTION
## Summary
Consolidates the safe dependabot PRs (#143, #142, #141, #129, #127, #125, #122, #123) into a single change against current `main` so we can verify them together. The older PRs will be closed in favor of this one.

### GitHub Actions
- `actions/checkout` v4 → v6
- `actions/cache` v3 → v5
- `actions/upload-artifact` v4 → v6
- `actions/upload-pages-artifact` v3 → v4
- `actions/configure-pages` v3 → v5

### Python requirements
- `flake8-qgis` `<1.1` → `<1.2`
- `pre-commit` `<4` → `<5`
- `sphinx-rtd-theme` `<3` → `<4`

Excluded (need closer review):
- #126 sphinx-autobuild `2021.*` → `2024.*` (3-year jump)
- #132 pytest-cov bump (CI was failing; package isn't even in our requirements files)

## Test plan
- [ ] CI workflows (tester, linter, documentation, releaser) all pass with the new action versions
- [ ] pre-commit still works locally