### PR TITLE
Pin sphinx-autobuild to 2024.* for Python 3.9 compat

### DIFF
--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -2,6 +2,6 @@
 # -----------------------
 
 myst-parser[linkify]>=1,<3
-sphinx-autobuild==2025.*
+sphinx-autobuild==2024.*
 sphinx-copybutton>=0.2,<1
 sphinx-rtd-theme>=1,<4


### PR DESCRIPTION
## Summary
The docs CI job runs on Python 3.9, but `sphinx-autobuild==2025.*` requires Python ≥3.10/3.11, breaking `main`. Pin to `2024.*` which still ships 3.9-compatible wheels.

This reverts the version change from #126 but keeps the intent (modernize away from 2021.*).

## Test plan
- [ ] Documentation workflow installs successfully